### PR TITLE
[Postgres] Switched to Querier Interface.

### DIFF
--- a/pkg/postgres/main_test.go
+++ b/pkg/postgres/main_test.go
@@ -120,7 +120,7 @@ func insertTestUsers(t *testing.T) {
 
 	defer cancel()
 
-	rows, err := connection.Query.db.Query(ctx, query)
+	rows, err := connection.queries.db.Query(ctx, query)
 	rows.Close()
 
 	require.NoError(t, err, "failed to wipe users table before reinserting users.")
@@ -145,7 +145,7 @@ func resetTestFiatAccounts(t *testing.T) (uuid.UUID, uuid.UUID) {
 
 	defer cancel()
 
-	rows, err := connection.Query.db.Query(ctx, query)
+	rows, err := connection.queries.db.Query(ctx, query)
 	rows.Close()
 
 	require.NoError(t, err, "failed to wipe fiat accounts table before reinserting accounts.")
@@ -181,7 +181,7 @@ func resetTestFiatJournal(t *testing.T, clientID1, clientID2 uuid.UUID) {
 
 	defer cancel()
 
-	rows, err := connection.Query.db.Query(ctx, query)
+	rows, err := connection.queries.db.Query(ctx, query)
 	rows.Close()
 
 	require.NoError(t, err, "failed to wipe fiat journal table before reinserting entries.")

--- a/pkg/postgres/postgres.go
+++ b/pkg/postgres/postgres.go
@@ -20,10 +20,11 @@ import (
 
 // Postgres contains objects required to interface with the database.
 type Postgres struct {
-	conf   config
-	pool   *pgxpool.Pool
-	logger *logger.Logger
-	Query  *Queries
+	conf    config
+	pool    *pgxpool.Pool
+	logger  *logger.Logger
+	queries *Queries
+	Query   Querier
 }
 
 // NewPostgres will create a new Postgres configuration and load it from disk.
@@ -81,7 +82,8 @@ func (p *Postgres) Open() error {
 	}
 
 	// Setup SQLC DBTX interface.
-	p.Query = New(p.pool)
+	p.queries = New(p.pool)
+	p.Query = p.queries
 
 	return nil
 }

--- a/pkg/postgres/transactions.go
+++ b/pkg/postgres/transactions.go
@@ -95,7 +95,7 @@ func (p *Postgres) FiatExternalTransfer(parentCtx context.Context, xferDetails *
 		}
 	}()
 
-	queryTx := p.Query.WithTx(tx)
+	queryTx := p.queries.WithTx(tx)
 
 	// Row lock the destination account.
 	if _, err = queryTx.FiatRowLockAccount(ctx, &FiatRowLockAccountParams{
@@ -239,7 +239,7 @@ func (p *Postgres) FiatInternalTransfer(parentCtx context.Context, src, dst *Fia
 	}()
 
 	// Configure transaction query connection.
-	queryTx := p.Query.WithTx(tx)
+	queryTx := p.queries.WithTx(tx)
 
 	// Row lock the accounts in order and check balances.
 	if err = fiatTransactionRowLockAndBalanceCheck(ctx, queryTx, src, dst); err != nil {

--- a/pkg/postgres/transactions_test.go
+++ b/pkg/postgres/transactions_test.go
@@ -370,7 +370,7 @@ func TestTransactions_FiatTransactionRowLockAndBalanceCheck(t *testing.T) {
 
 			defer tx.Rollback(ctx) //nolint:errcheck
 
-			queryTx := connection.Query.WithTx(tx)
+			queryTx := connection.queries.WithTx(tx)
 
 			err = fiatTransactionRowLockAndBalanceCheck(ctx, queryTx, &test.source, &test.destination)
 			test.errExpectation(t, err, "failed error expectation")


### PR DESCRIPTION
All calls to SQLC generated queries are now made through the `Querier` interface.