### PR TITLE
[Postgres] Cryptocurrency Rounding in Balance.

### DIFF
--- a/SQL/README.md
+++ b/SQL/README.md
@@ -409,7 +409,7 @@ liquibase update
 
 ```bash
 # Main database rollback. Specify number of steps.
-liquibase rollback-count 9
+liquibase rollback-count 11
 ```
 
 
@@ -420,5 +420,5 @@ liquibase update --defaultsFile liquibase_testsuite.properties
 
 ```bash
 # Test suite setup
-liquibase rollback-count 9 --defaultsFile liquibase_testsuite.properties
+liquibase rollback-count 11 --defaultsFile liquibase_testsuite.properties
 ```

--- a/SQL/schema/migration.sql
+++ b/SQL/schema/migration.sql
@@ -219,12 +219,6 @@ AS '
       -- Generate the timestamp with timezone for this transaction.
       SELECT NOW() INTO STRICT current_timestamp;
 
-      -- Round Half-to-Even the Fiat debit amount.
-      _fiat_debit_amount = round_half_even(_fiat_debit_amount, 2);
-
-      -- Round Half-to-Even the Crypto credit amount.
-      _crypto_credit_amount = round_half_even(_crypto_credit_amount, 8);
-
       -- Get FTeX operations account IDs.
       SELECT client_id INTO STRICT ftex_fiat_id
       FROM users
@@ -330,12 +324,6 @@ AS '
     BEGIN
       -- Generate the timestamp with timezone for this transaction.
       SELECT NOW() INTO STRICT current_timestamp;
-
-      -- Round Half-to-Even the Fiat credit amount.
-      _fiat_credit_amount = round_half_even(_fiat_credit_amount, 2);
-
-      -- Round Half-to-Even the Crypto debit amount.
-      _crypto_debit_amount = round_half_even(_crypto_debit_amount, 8);
 
       -- Get FTeX operations account IDs.
       SELECT client_id INTO STRICT ftex_fiat_id


### PR DESCRIPTION
To minimize the precision effects of rounding the round half-to-even operation is only applied when updating the account balances.